### PR TITLE
Don't output missing gem info from `bundle check`

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -8,7 +8,7 @@ APP_ROOT = Pathname.new File.expand_path('../../',  __FILE__)
 Dir.chdir APP_ROOT do
   puts '== Installing dependencies =='
   system 'gem install bundler --conservative'
-  system 'bundle check || bundle install'
+  system 'bundle check > /dev/null || bundle install'
 
   puts "\n== Generating secret tokens =="
   unless File.exist?('config/secrets.yml')


### PR DESCRIPTION
It can seem confusing the first time someone runs setup -- a big red message with missing gems. It's not a huge deal, feel free to either take it, or leave it.