### PR TITLE
Reorganize code to use guard clauses

### DIFF
--- a/app/controllers/door/statuses_controller.rb
+++ b/app/controllers/door/statuses_controller.rb
@@ -10,27 +10,36 @@ class Door::StatusesController < ApplicationController
   def update
     @action = Door::Actions::Action.from_name status_params[:name]
 
-    if @action.present?
-      if @action.creatable_by? current_user
-        @action.initiator = current_user
-        @action.origin_information = "Remote Host: #{current_ip_address}"
-        if @action.save
-          flash[:notice] = I18n.t('views.door_status.action_executed_successfuly', action: @action)
-          Rails.cache.delete('door_current_status')
-        else
-          flash[:error] = I18n.t('views.door_status.action_executed_unsuccessfuly')
-        end
-      else
-        flash[:error] = I18n.t('views.door_status.forbidden')
-      end
-    else
-      flash[:error] = I18n.t('views.door_status.invalid_action')
+    if @action.blank?
+      return update_error('views.door_status.invalid_action')
     end
 
-    redirect_to :back
+    if not @action.creatable_by? current_user
+      return update_error('views.door_status.forbidden')
+    end
+
+    @action.initiator = current_user
+    @action.origin_information = "Remote Host: #{current_ip_address}"
+
+    if @action.save
+      update_success('views.door_status.action_executed_successfuly', action: @action)
+      Rails.cache.delete('door_current_status')
+    else
+      update_error('views.door_status.action_executed_unsuccessfuly')
+    end
   end
 
   private
+
+  def update_error(message, args = {})
+    flash[:error] = I18n.t(message, args)
+    redirect_to :back
+  end
+
+  def update_success(message, args = {})
+    flash[:notice] = I18n.t(message, args)
+    redirect_to :back
+  end
 
   def status_params
     params.require(:status).permit :name

--- a/spec/controllers/door/statuses_controller_spec.rb
+++ b/spec/controllers/door/statuses_controller_spec.rb
@@ -110,7 +110,6 @@ describe Door::StatusesController, type: :controller do
 
         end
 
-
         describe 'when the status can be saved' do
           before do
             allow(action).to receive(:save).and_return(true)


### PR DESCRIPTION
Better to decide how to bail out early, rather than nest the conditions. The error messages end up being closer to the conditions they're connected with.