### PR TITLE
Share log entries between models

### DIFF
--- a/app/models/door/log_entry.rb
+++ b/app/models/door/log_entry.rb
@@ -1,7 +1,0 @@
-module Door
-  class LogEntry < ActiveRecord::Base
-    self.table_name_prefix = 'door_'
-
-    belongs_to :loggable, polymorphic: true
-  end
-end

--- a/app/models/log_entry.rb
+++ b/app/models/log_entry.rb
@@ -1,3 +1,3 @@
-class Lights::LogEntry < ActiveRecord::Base
+class LogEntry < ActiveRecord::Base
   belongs_to :loggable, polymorphic: true
 end

--- a/db/migrate/20160723155531_merge_log_entries.rb
+++ b/db/migrate/20160723155531_merge_log_entries.rb
@@ -1,0 +1,45 @@
+class MergeLogEntries < ActiveRecord::Migration
+  class DoorLogEntry < ActiveRecord::Base
+  end
+
+  def up
+    create_table :log_entries do |t|
+      t.integer :loggable_id, null: false
+      t.string :loggable_type, null: false
+
+      t.timestamps null: false
+    end
+
+    DoorLogEntry.find_each do |log_entry|
+      LogEntry.create!({
+        loggable_id:   log_entry.loggable_id,
+        loggable_type: log_entry.loggable_type,
+      })
+    end
+
+    drop_table :door_log_entries
+    drop_table :lights_log_entries
+  end
+
+  def down
+    create_table :door_log_entries do |t|
+      t.integer :loggable_id
+      t.string :loggable_type
+    end
+
+    create_table :lights_log_entries do |t|
+      t.integer :loggable_id
+      t.string :loggable_type
+      t.timestamps null: false
+    end
+
+    LogEntry.find_each do |log_entry|
+      DoorLogEntry.create!({
+        loggable_id:   log_entry.loggable_id,
+        loggable_type: log_entry.loggable_type,
+      })
+    end
+
+    drop_table :log_entries
+  end
+end

--- a/spec/support/shared_examples/loggable.rb
+++ b/spec/support/shared_examples/loggable.rb
@@ -1,7 +1,7 @@
 shared_examples 'loggable' do
   it 'creates an associated log entry when created' do
     model = create subject.model_name.singular.to_sym
-    expect(model.log_entry).to be_a Door::LogEntry
+    expect(model.log_entry).to be_a LogEntry
     expect(model.log_entry.loggable).to eq model
   end
 end


### PR DESCRIPTION
No point in namespacing log entries for Door and Lights.