### PR TITLE
Manifest file for chrome apps

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -13,6 +13,8 @@ html lang="#{I18n.locale}"
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true
     = javascript_include_tag 'application', 'data-turbolinks-track' => true
     = csrf_meta_tags
+
+    link rel="manifest" href="manifest.json"
   body
     = render partial: 'layouts/navigation'
     = render partial: 'layouts/flash'

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,5 @@
+{
+  "name": "initLab Fauna",
+  "short_name": "Fauna",
+  "display": "standalone"
+}


### PR DESCRIPTION
Ironically enough, while the documentation for the manifest is present in MDN, firefox on Android doesn't seem to grok this. It seems to work for chrome on Android, though.