### PR TITLE
Add meta tags for theme color on Chrome/Android and back/forward buttons color on IE

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -7,6 +7,9 @@ html lang="#{I18n.locale}"
       = content_for?(:title) ? "#{yield(:title)} | Fauna" : 'Fauna'
 
     meta name="viewport" content="width=device-width, initial-scale=1"
+	
+    meta name="theme-color" content="#2196f3"
+    meta name="msapplication-navbutton-color" content="#2196f3"
 
     = render partial: 'layouts/icons'
 


### PR DESCRIPTION
References:
https://developers.google.com/web/updates/2014/11/Support-for-theme-color-in-Chrome-39-for-Android
https://msdn.microsoft.com/en-us/library/gg491732%28v=vs.85%29.aspx?f=255&MSPPError=-2147217396#msapplication-navbutton-color