### PR TITLE
Remove useless header

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,7 +13,6 @@ class UsersController < ApplicationController
     def set_access_control_headers
       if request.format.json?
         response.headers['Access-Control-Allow-Origin'] = '*'
-        response.headers['Access-Control-Request-Method'] = '*'
       end
     end
 end


### PR DESCRIPTION
Access-Control-Request-Method is a request header, not a response header. It has no meaning in this context.