### PR TITLE
Fix paging styles in user administation

### DIFF
--- a/app/views/fauna/users/index.html.slim
+++ b/app/views/fauna/users/index.html.slim
@@ -16,5 +16,5 @@ section.container
           tbody#user_table
             = render @users
     .row
-      .col-sm-4.col-sm-offset-4.text-center#pagination
+      .col-sm-12.text-center#pagination
         = paginate @users, remote: true


### PR DESCRIPTION
No need for the offset "hack" to center the
paging buttons. Only `.text-center` is enough

Fixes: https://github.com/initLab/fauna/issues/88