### PR TITLE
Remove IRC logging of door events

### DIFF
--- a/app/models/concerns/door/loggable.rb
+++ b/app/models/concerns/door/loggable.rb
@@ -4,7 +4,7 @@ module Door::Loggable
   included do
     has_one :log_entry, as: :loggable
     before_create :associate_log_entry
-    after_create :spam_irc
+    #after_create :spam_irc
   end
 
   def public_message


### PR DESCRIPTION
Notifications are now sent by https://github.com/initLab/irc-notifier