### PR TITLE
Sensors 2.2 - changed data source and frequency

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -39,9 +39,13 @@ $(function() {
     });
 
     mqttClient.on('message', function(topic, data, message) {
-        if (message.retain) {
-            return;
-        }
+        // Xiaomi BLE devices send data rarely (10 min), unlike the Espurna-based devices,
+        // which can send data every 6 secs. It would be a better idea to just show the retained
+        // measurements on page load, instead of waiting for a fresh one.
+        //
+        // if (message.retain) {
+        //     return;
+        // }
 
         const element = $('[data-mqtt-topic="' + topic + '"]');
 

--- a/app/views/sensors/index.html.slim
+++ b/app/views/sensors/index.html.slim
@@ -7,5 +7,5 @@ section.container
     .row
       - @grafana[type]['panels'].each do |panelId|
         .col-sm-4
-          a href="https://stats.initlab.org/d/#{@grafana[type]['dashboard']['id']}/temperature" target="_blank"
+          a href="https://stats.initlab.org/d/#{@grafana[type]['dashboard']['id']}/#{@grafana[type]['dashboard']['name']}" target="_blank"
             img.grafana-chart src="https://stats.initlab.org/render/d-solo/#{@grafana[type]['dashboard']['id']}/#{@grafana[type]['dashboard']['name']}?orgId=1&panelId=#{panelId}&width=350&height=200&tz=Europe%2FSofia" alt=""

--- a/config/sensors.yml
+++ b/config/sensors.yml
@@ -1,7 +1,7 @@
 grafana:
   temperature:
     dashboard:
-      id: 000000008
+      id: C-7GPzXMk
       name: temperatures
     panels:
       - 4
@@ -9,7 +9,7 @@ grafana:
       - 10
   humidity:
     dashboard:
-      id: 000000009
+      id: d19kszuGk
       name: humidity
     panels:
       - 4
@@ -17,9 +17,9 @@ grafana:
       - 10
 mqtt:
   sensors:
-    - label: Outside
-      topic: sensor-outside-espurna/temperature
-    - label: Lecture room
-      topic: sensor-lecture-room-espurna/temperature
-    - label: Ruby room
-      topic: sensor-ruby-room-espurna/temperature
+    - label: Big room
+      topic: sensors-xiaomi-ble/big-room/temperature
+    - label: Small room
+      topic: sensors-xiaomi-ble/small-room/temperature
+    - label: Kitchen
+      topic: sensors-xiaomi-ble/kitchen/temperature


### PR DESCRIPTION
- do not skip messages with retain: true
- update sensor names, MQTT topics and dashboard IDs to match the setup at the new location of init Lab
- fix bug in Grafana link URL