### PR TITLE
Revert "Remove IRC logging of door events"

### DIFF
--- a/app/models/concerns/door/loggable.rb
+++ b/app/models/concerns/door/loggable.rb
@@ -4,7 +4,7 @@ module Door::Loggable
   included do
     has_one :log_entry, as: :loggable
     before_create :associate_log_entry
-    #after_create :spam_irc
+    after_create :spam_irc
   end
 
   def public_message


### PR DESCRIPTION
This reverts commit d80d873fb65b6a187f3cafa2c5617f60c135a77e.

The IRC bot doesn't know (yet) who performed the action, so Fauna should send the notifications until this is implemented.